### PR TITLE
*feat: Log in seperate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 ~$*.docx
 *.b64
 testdata/
+*.log

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,20 @@
     </encoder>
   </appender>
 
+  <appender name="file" class="ch.qos.logback.core.FileAppender">
+    <file>efgs.log</file>
+    <append>true</append>
+    <immediateFlush>true</immediateFlush>
+    <encoder>
+      <pattern>
+        timestamp=%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC}, level=%level, hostname=${HOSTNAME}, pid=${PID:-}, trace=%X{traceId:-}, span=%X{spanId:-}, thread=%thread, class=%logger{40}, message="%m"%n
+      </pattern>
+      <charset>utf8</charset>
+    </encoder>
+  </appender>
+
   <root level="INFO">
     <appender-ref ref="console"/>
+    <appender-ref ref="file"/>
   </root>
 </configuration>


### PR DESCRIPTION
Because of a requirement of the ops team we need an explicit log file. So I've added a FileAppender to our logback config which will write all messages in the same format as to the console in the file efgs.log