### PR TITLE
Removed setup of BouncyCastly provider

### DIFF
--- a/src/main/java/eu/interop/federationgateway/batchsigning/BatchSignatureVerifier.java
+++ b/src/main/java/eu/interop/federationgateway/batchsigning/BatchSignatureVerifier.java
@@ -28,8 +28,6 @@ import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
@@ -50,7 +48,6 @@ import org.bouncycastle.cms.SignerInformation;
 import org.bouncycastle.cms.SignerInformationStore;
 import org.bouncycastle.cms.SignerInformationVerifier;
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.util.Store;
 import org.springframework.stereotype.Service;
@@ -66,7 +63,6 @@ public class BatchSignatureVerifier {
 
   public BatchSignatureVerifier(CertificateService certificateService) {
     this.certificateService = certificateService;
-    Security.addProvider(new BouncyCastleProvider());
   }
 
   /**
@@ -180,21 +176,19 @@ public class BatchSignatureVerifier {
       signature.initVerify(x509Certificate.getPublicKey());
       signature.update(x509Certificate.getTBSCertificate());
       return signature.verify(x509Certificate.getSignature());
-    } catch (NoSuchAlgorithmException | SignatureException | CertificateException | InvalidKeyException
-      | NoSuchProviderException e) {
+    } catch (NoSuchAlgorithmException | SignatureException | CertificateException | InvalidKeyException e) {
       log.error("Could not verify signature of signing certificate: " + e.getMessage());
       return false;
     }
   }
 
   private Signature createSignatureInstance(final X509Certificate x509Certificate)
-    throws NoSuchAlgorithmException, NoSuchProviderException {
-    return Signature.getInstance(x509Certificate.getSigAlgName(), BouncyCastleProvider.PROVIDER_NAME);
+    throws NoSuchAlgorithmException {
+    return Signature.getInstance(x509Certificate.getSigAlgName());
   }
 
   private X509Certificate toX509Certificate(final X509CertificateHolder certificate) throws CertificateException {
     final JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
-    converter.setProvider(BouncyCastleProvider.PROVIDER_NAME);
     return converter.getCertificate(certificate);
   }
 
@@ -238,7 +232,7 @@ public class BatchSignatureVerifier {
 
   private SignerInformationVerifier createSignerInfoVerifier(final X509CertificateHolder signerCert)
     throws OperatorCreationException, CertificateException {
-    return new JcaSimpleSignerInfoVerifierBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME).build(signerCert);
+    return new JcaSimpleSignerInfoVerifierBuilder().build(signerCert);
   }
 
 }

--- a/src/test/java/eu/interop/federationgateway/TestData.java
+++ b/src/test/java/eu/interop/federationgateway/TestData.java
@@ -53,7 +53,6 @@ import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -83,7 +82,6 @@ public class TestData {
   public static final String AUTH_CERT_HASH = "69c697c045b4cdaa441a28af0ec1cc4128153b9ddc796b66bfa04b02ea3e103e";
   public static final int DAYS_SINCE_ONSET_OF_SYMPTOMS = 42;
   public static final String DIGEST_ALGORITHM = "SHA1withRSA";
-  public static final String CRYPTO_PROVIDER = BouncyCastleProvider.PROVIDER_NAME;
   private static final String TEST_BATCH_TAG_DE = "uploaderBatchTag_DE";
   private static final String TEST_BATCH_TAG_NL = "uploaderBatchTag_NL";
   private static final String COMMON_NAME_SIGNING_CERT = "demo";
@@ -151,13 +149,13 @@ public class TestData {
     X500Name dnName = new X500Name("C=" + TestData.AUTH_CERT_COUNTRY + ", CN=" + COMMON_NAME_SIGNING_CERT);
     BigInteger certSerial = new BigInteger(Long.toString(System.currentTimeMillis()));
 
-    ContentSigner contentSigner = new JcaContentSignerBuilder(DIGEST_ALGORITHM).setProvider(CRYPTO_PROVIDER).build(TestData.keyPair.getPrivate());
+    ContentSigner contentSigner = new JcaContentSignerBuilder(DIGEST_ALGORITHM).build(TestData.keyPair.getPrivate());
     JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(dnName, certSerial, validFrom, validTo, dnName, TestData.keyPair.getPublic());
 
     BasicConstraints basicConstraints = new BasicConstraints(false);
     certBuilder.addExtension(new ASN1ObjectIdentifier("2.5.29.19"), true, basicConstraints);
 
-    return new JcaX509CertificateConverter().setProvider(Security.getProvider(CRYPTO_PROVIDER)).getCertificate(certBuilder.build(contentSigner));
+    return new JcaX509CertificateConverter().getCertificate(certBuilder.build(contentSigner));
   }
 
   public static void createCertificates() throws NoSuchAlgorithmException, CertificateException, CertIOException, OperatorCreationException {


### PR DESCRIPTION
We got an "X.509 not found" error on dev environment. Removing of the ```addProvider()``` method fixes this behaviour.