### PR TITLE
*fix: surrounded complex MDC parameters with parentesis

### DIFF
--- a/src/main/java/eu/interop/federationgateway/config/ProtobufHttpMessageConverter.java
+++ b/src/main/java/eu/interop/federationgateway/config/ProtobufHttpMessageConverter.java
@@ -103,7 +103,7 @@ public class ProtobufHttpMessageConverter extends AbstractHttpMessageConverter<M
       targetContentTypeVersion = properties.getContentNegotiation().getJsonVersion();
     }
 
-    MDC.put("requestedMediaType", contentType.toString());
+    MDC.put("requestedMediaType", "\"" + contentType.toString() + "\"");
 
     if (targetContentType == null) {
       log.error("Accepted Content-Type is not compatible");
@@ -159,7 +159,7 @@ public class ProtobufHttpMessageConverter extends AbstractHttpMessageConverter<M
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Accept must be set!");
     }
 
-    MDC.put("requestedMediaType", contentType.toString());
+    MDC.put("requestedMediaType", "\"" + contentType.toString() + "\"");
 
     MediaType targetContentType = null;
     String targetContentTypeVersion = null;

--- a/src/main/java/eu/interop/federationgateway/filter/CertificateAuthentificationFilter.java
+++ b/src/main/java/eu/interop/federationgateway/filter/CertificateAuthentificationFilter.java
@@ -108,7 +108,7 @@ public class CertificateAuthentificationFilter extends OncePerRequestFilter {
     headerCertThumbprint = headerCertThumbprint.replace(":", "");
     headerCertThumbprint = headerCertThumbprint.toLowerCase();
 
-    MDC.put("dnString", headerDistinguishedName);
+    MDC.put("dnString", "\"" + headerDistinguishedName + "\"");
     MDC.put("thumbprint", headerCertThumbprint);
 
     Map<String, String> distinguishNameMap = parseDistinguishNameString(headerDistinguishedName);

--- a/src/main/java/eu/interop/federationgateway/service/CallbackService.java
+++ b/src/main/java/eu/interop/federationgateway/service/CallbackService.java
@@ -180,7 +180,7 @@ public class CallbackService {
     URL url;
     InetAddress hostAddress;
 
-    MDC.put("url", urlToCheck);
+    MDC.put("url", "\"" + urlToCheck + "\"");
 
     try {
       url = new URL(urlToCheck);

--- a/src/main/java/eu/interop/federationgateway/service/CallbackTaskExecutorService.java
+++ b/src/main/java/eu/interop/federationgateway/service/CallbackTaskExecutorService.java
@@ -67,7 +67,7 @@ public class CallbackTaskExecutorService {
 
       MDC.put("callbackId", subscription.getCallbackId());
       MDC.put("country", subscription.getCountry());
-      MDC.put("url", subscription.getUrl());
+      MDC.put("url", "\"" + subscription.getUrl() + "\"");
 
       if (!callbackService.checkUrl(subscription.getUrl(), subscription.getCountry())) {
         log.error("Security check for callback url has failed. Deleting callback subscription.");

--- a/src/main/java/eu/interop/federationgateway/service/CertificateService.java
+++ b/src/main/java/eu/interop/federationgateway/service/CertificateService.java
@@ -61,7 +61,7 @@ public class CertificateService {
     try {
       return getCallbackCertificateForHost(new URL(url).getHost(), country);
     } catch (MalformedURLException ignored) {
-      MDC.put("url", url);
+      MDC.put("url", "\"" + url + "\"");
       log.error("Could not parse url.");
       return Optional.empty();
     }

--- a/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyBatchService.java
+++ b/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyBatchService.java
@@ -154,7 +154,7 @@ public class DiagnosisKeyBatchService {
       .map(DiagnosisKeyEntity::getFormat)
       .anyMatch(Predicate.not(diagnosisKey.get().getFormat()::equals))) {
 
-      MDC.put("format", diagnosisKey.get().getFormat().toString());
+      MDC.put("format", "\"" + diagnosisKey.get().getFormat().toString() + "\"");
 
       log.error("Stop batching process, while try to batch {} keys, but the keys have different format versions",
         diagnosisKeyEntitys.size());


### PR DESCRIPTION
Added parentesis to MDC logging parameters to not break log format.