### PR TITLE
Swap conditions according to methods called inside

### DIFF
--- a/src/test/java/eu/interop/federationgateway/batchsigning/SignatureGenerator.java
+++ b/src/test/java/eu/interop/federationgateway/batchsigning/SignatureGenerator.java
@@ -81,10 +81,10 @@ public class SignatureGenerator {
                       final boolean signerInfoMustBeAdded)
     throws CertificateEncodingException, OperatorCreationException, IOException, CMSException {
     final CMSSignedDataGenerator signedDataGenerator = new CMSSignedDataGenerator();
-    if (certMustBeAdded) {
+    if (signerInfoMustBeAdded) {
       signedDataGenerator.addSignerInfoGenerator(createSignerInfo(cert));
     }
-    if (signerInfoMustBeAdded) {
+    if (certMustBeAdded) {
       signedDataGenerator.addCertificate(createCertificateHolder(cert));
     }
     CMSSignedData singedData = signedDataGenerator.generate(new CMSProcessableByteArray(data), false);


### PR DESCRIPTION
When calling `addSignerInfoGenerator` method, a parameter named
`signerInfoMustBeAdded` should be checked, not `certMustBeAdded`.
The same goes for `addCertificate` method, `certMustBeAdded`
parameter should be checked before calling it.