### PR TITLE
fix: Return number of possibly inserted keys on upload failure.

### DIFF
--- a/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyEntityService.java
+++ b/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyEntityService.java
@@ -94,7 +94,6 @@ public class DiagnosisKeyEntityService {
     });
 
     if (resultMap.get(409).size() > 0 || resultMap.get(500).size() > 0) {
-      resultMap.get(201).clear();
 
       EfgsMdc.put("insertedKeyCount", resultMap.get(201).size());
       EfgsMdc.put("conflictKeysCount", resultMap.get(409).size());

--- a/src/test/java/eu/interop/federationgateway/controller/UploadControllerTest.java
+++ b/src/test/java/eu/interop/federationgateway/controller/UploadControllerTest.java
@@ -235,8 +235,9 @@ public class UploadControllerTest {
         List<Integer> list500 = (List<Integer>) map.get("500");
 
         Assert.assertTrue(list500.isEmpty());
-        Assert.assertTrue(list201.isEmpty());
+        Assert.assertTrue(list201.contains(1));
         Assert.assertTrue(list409.contains(0));
+        Assert.assertEquals(1, list201.size());
         Assert.assertEquals(1, list409.size());
       });
   }

--- a/src/test/java/eu/interop/federationgateway/service/DiagnosisKeyEntityServiceTest.java
+++ b/src/test/java/eu/interop/federationgateway/service/DiagnosisKeyEntityServiceTest.java
@@ -128,7 +128,8 @@ public class DiagnosisKeyEntityServiceTest {
     try {
       diagnosisKeyEntityService.saveDiagnosisKeyEntities(List.of(testEntity, testEntity2, testEntity3));
     } catch (DiagnosisKeyEntityService.DiagnosisKeyInsertException e) {
-      Assert.assertTrue(e.getResultMap().get(201).isEmpty());
+      Assert.assertTrue(e.getResultMap().get(201).contains(0));
+      Assert.assertTrue(e.getResultMap().get(201).contains(2));
       Assert.assertTrue(e.getResultMap().get(500).isEmpty());
       Assert.assertTrue(e.getResultMap().get(409).contains(1));
 


### PR DESCRIPTION
Changed behaviour of upload to return ids of possibly inserted keys on failure.

This fixes #135 