### PR TITLE
runtime improvements

### DIFF
--- a/src/main/java/eu/interop/federationgateway/mapper/DiagnosisKeyMapper.java
+++ b/src/main/java/eu/interop/federationgateway/mapper/DiagnosisKeyMapper.java
@@ -31,6 +31,7 @@ import eu.interop.federationgateway.utils.SemVerUtils;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -131,7 +132,7 @@ public abstract class DiagnosisKeyMapper {
         certificateCountry,
         format
       ))
-      .collect(Collectors.toList());
+      .collect(Collectors.toCollection(ArrayList::new));
   }
 
   /**

--- a/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyEntityService.java
+++ b/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyEntityService.java
@@ -79,8 +79,8 @@ public class DiagnosisKeyEntityService {
 
     ZonedDateTime uploadTimestamp = ZonedDateTime.now(ZoneOffset.UTC);
 
-    diagnosisKeyEntities.forEach(key -> {
-      int index = diagnosisKeyEntities.indexOf(key);
+    for (int index = 0; index < diagnosisKeyEntities.size(); index++) {
+      DiagnosisKeyEntity key = diagnosisKeyEntities.get(index);
       key.setCreatedAt(uploadTimestamp);
       try {
         saveDiagnosisKeyEntity(key);
@@ -91,7 +91,7 @@ public class DiagnosisKeyEntityService {
       } catch (Exception e) {
         resultMap.get(500).add(index);
       }
-    });
+    }
 
     if (!resultMap.get(409).isEmpty() || !resultMap.get(500).isEmpty()) {
 


### PR DESCRIPTION
The loop in `saveDiagnosisKeyEntities` is currently O(n^2) complexity because the delegated lambda is immediately calling indexOf on the key.

Proposed

* use standard for loop and get(i)
* ensure that the list is of ArrayList type (it already likely was by default, but Collectors.toList does not force an implementation).