### PR TITLE
update diagnosis key validation

### DIFF
--- a/src/main/java/eu/interop/federationgateway/validator/DiagnosisKeyBatchValidator.java
+++ b/src/main/java/eu/interop/federationgateway/validator/DiagnosisKeyBatchValidator.java
@@ -17,16 +17,16 @@ public class DiagnosisKeyBatchValidator implements
 
     List<EfgsProto.DiagnosisKey> diagnosisKeys = diagnosisKeyBatch.getKeysList();
     for (EfgsProto.DiagnosisKey diagnosisKey : diagnosisKeys) {
-      if (diagnosisKey.getReportType() == EfgsProto.ReportType.UNKNOWN) {
-        log.error(VALIDATION_FAILED_MESSAGE + "Invalid report-type.");
-        return false;
-      } else if (diagnosisKey.getKeyData() == null || diagnosisKey.getKeyData().isEmpty()) {
+      if (diagnosisKey.getKeyData() == null || diagnosisKey.getKeyData().isEmpty()) {
         log.error(VALIDATION_FAILED_MESSAGE + "The keydata is empty or null.");
         return false;
-      } else if (diagnosisKey.getRollingPeriod() == 0) {
+      } else if (diagnosisKey.getKeyData().size() != 16) {
+        log.error(VALIDATION_FAILED_MESSAGE + "The keydata is not 16 bytes.");
+        return false;
+      } else if (diagnosisKey.getRollingPeriod() == 0 || diagnosisKey.getRollingPeriod() > 144) {
         log.error(VALIDATION_FAILED_MESSAGE + "Invalid rolling period.");
         return false;
-      } else if (diagnosisKey.getTransmissionRiskLevel() == 0 || diagnosisKey.getTransmissionRiskLevel() > 8) {
+      } else if (diagnosisKey.getTransmissionRiskLevel() < 0 || diagnosisKey.getTransmissionRiskLevel() > 8) {
         log.error(VALIDATION_FAILED_MESSAGE + "Invalid transmission risk level.");
         return false;
       }

--- a/src/test/java/eu/interop/federationgateway/TestData.java
+++ b/src/test/java/eu/interop/federationgateway/TestData.java
@@ -85,8 +85,8 @@ public class TestData {
   public static final int ROLLING_PERIOD = 1;
   public static final int ROLLING_START_INTERVAL_NUMBER = 2;
   public static final int TRANSMISSION_RISK_LEVEL = 3;
-  public static final String PAYLOAD_HASH = "13251f41adc9f8723dedf450ba9e1506e851742afdfb0cd39a38cee8d21eccf0";
-  public static final byte[] BYTES = new byte[]{14, 15, 11, 14, 12, 15, 15, 16};
+  public static final String PAYLOAD_HASH = "6c50e8474f965e2c7fa4033b7b46293559bd9ea0749fc2ca873ab2b11bb2ad7f";
+  public static final byte[] BYTES = new byte[]{14, 15, 11, 14, 12, 15, 15, 16, 14, 15, 11, 14, 12, 15, 15, 16};
   public static final String DN_STRING_DE = "C=DE";
   public static final String AUTH_CERT_COUNTRY = "DE";
   public static final String CALLBACK_ID_FIRST = "firstCallback";


### PR DESCRIPTION
Align diagnosis key validation to be more in line with apple+google export proto expectations

- check that diagnosis keys are exactly 16 bytes 

- check upper end of invalid rolling period, not just lower end

- 0 is a valid transmission risk level, and what may be present if that is omitted (client is only sending reportType)
  - on the matching side, 0 is used as 1, at least on Android matching

- update test data to have 16 byte keys by default, update associated test hash value

- add additional test cases for key validation