### PR TITLE
Naming convention for SNAPSHOT versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>eu.interop.federationgateway</groupId>
   <artifactId>efgs-federation-gateway</artifactId>
-  <version>1.0.1.SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>${packaging.format}</packaging>
 
   <name>efgs-federation-gateway</name>


### PR DESCRIPTION
Naming convention is with hyphen (-) not point (.). 

It should be 1.0.1.-SNAPSHOT; not 1.0.1.SNAPSHOT.