### PR TITLE
fix: visited countries array contains empty string if visited countries is empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>eu.interop.federationgateway</groupId>
   <artifactId>efgs-federation-gateway</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>${packaging.format}</packaging>
 
   <name>efgs-federation-gateway</name>

--- a/src/main/java/eu/interop/federationgateway/mapper/DiagnosisKeyMapper.java
+++ b/src/main/java/eu/interop/federationgateway/mapper/DiagnosisKeyMapper.java
@@ -156,14 +156,6 @@ public abstract class DiagnosisKeyMapper {
       .build();
   }
 
-  private List<String> parseVisitedCountries(String input) {
-    if (StringUtils.isEmpty(input)) {
-      return Collections.emptyList();
-    } else {
-      return Arrays.asList(input.split(","));
-    }
-  }
-
   public abstract List<EfgsProto.DiagnosisKey> entityToProto(List<DiagnosisKeyEntity> entity);
 
   public byte[] byteStringToByteArray(ByteString byteString) {
@@ -182,4 +174,12 @@ public abstract class DiagnosisKeyMapper {
   public abstract DiagnosisKeyPayload.ReportType mapReportType(
     EfgsProto.ReportType reportType
   );
+
+  private List<String> parseVisitedCountries(String input) {
+    if (StringUtils.isEmpty(input)) {
+      return Collections.emptyList();
+    } else {
+      return Arrays.asList(input.split(","));
+    }
+  }
 }

--- a/src/main/java/eu/interop/federationgateway/mapper/DiagnosisKeyMapper.java
+++ b/src/main/java/eu/interop/federationgateway/mapper/DiagnosisKeyMapper.java
@@ -33,6 +33,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -41,6 +42,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ValueMapping;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Mapper(componentModel = "spring")
@@ -147,11 +149,19 @@ public abstract class DiagnosisKeyMapper {
       .setRollingStartIntervalNumber(entity.getPayload().getRollingStartIntervalNumber())
       .setRollingPeriod(entity.getPayload().getRollingPeriod())
       .setTransmissionRiskLevel(entity.getPayload().getTransmissionRiskLevel())
-      .addAllVisitedCountries(Arrays.asList(entity.getPayload().getVisitedCountries().split(",")))
+      .addAllVisitedCountries(parseVisitedCountries(entity.getPayload().getVisitedCountries()))
       .setOrigin(entity.getPayload().getOrigin())
       .setReportType(mapReportType(entity.getPayload().getReportType()))
       .setDaysSinceOnsetOfSymptoms(entity.getPayload().getDaysSinceOnsetOfSymptoms())
       .build();
+  }
+
+  private List<String> parseVisitedCountries(String input) {
+    if (StringUtils.isEmpty(input)) {
+      return Collections.emptyList();
+    } else {
+      return Arrays.asList(input.split(","));
+    }
   }
 
   public abstract List<EfgsProto.DiagnosisKey> entityToProto(List<DiagnosisKeyEntity> entity);

--- a/src/test/java/eu/interop/federationgateway/mapper/DiagnosiskeyMapperTest.java
+++ b/src/test/java/eu/interop/federationgateway/mapper/DiagnosiskeyMapperTest.java
@@ -24,6 +24,7 @@ import eu.interop.federationgateway.TestData;
 import eu.interop.federationgateway.entity.DiagnosisKeyEntity;
 import eu.interop.federationgateway.model.EfgsProto;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
@@ -68,6 +69,22 @@ public class DiagnosiskeyMapperTest {
     List<EfgsProto.DiagnosisKey> expected = Arrays.asList(
       TestData.getDiagnosisKeyProto(),
       TestData.getDiagnosisKeyProto()
+    );
+
+    Assert.assertEquals(converted, expected);
+  }
+
+  @Test
+  public void testMappingFromEntityToProtoVisitedCountriesEmpty() {
+    DiagnosisKeyEntity entity = TestData.getDiagnosisKeyTestEntityforCreation();
+    entity.getPayload().setVisitedCountries("");
+
+    List<EfgsProto.DiagnosisKey> converted = mapper.entityToProto(Collections.singletonList(
+      entity
+    ));
+
+    List<EfgsProto.DiagnosisKey> expected = Collections.singletonList(
+      TestData.getDiagnosisKeyProto().toBuilder().clearVisitedCountries().build()
     );
 
     Assert.assertEquals(converted, expected);


### PR DESCRIPTION
When downloading keys the visited countries array contains an ""-String when no visited countries were submitted to EFGS. It is expected that EFGS returns an empty array.