### PR TITLE
Fix: Make tools run on Linux and macos 

### DIFF
--- a/tools/create_callback_client_certificate.sh
+++ b/tools/create_callback_client_certificate.sh
@@ -9,7 +9,7 @@ certCN="EFGS-Callback DEV"
 certC="DE"              
 yn=N
 
-ECHO [1 of 6] Deleting old files...
+echo [1 of 6] Deleting old files...
 rm -f callback.pem
 rm -f callback.key
 rm -f callback.p12

--- a/tools/create_callback_client_certificate.sh
+++ b/tools/create_callback_client_certificate.sh
@@ -28,8 +28,19 @@ certC=${input:-${certC}}
 #        * ) echo "Please answer Y(es) or N(o).";;
 # esac
 #done
+
+case "$(uname -s)" in
+  MINGW32*|MSYS*|MINGW*)
+    # Work around MinGW/MSYS's path conversion (http://www.mingw.org/wiki/Posix_path_conversion) 
+    ertSubject="//C=${certC}\CN=${certCN}\O=EFGS DEV Org"
+  ;;
+  *)
+    certSubject="/C=${certC}/CN=${certCN}/O=EFGS DEV Org"
+  ;;
+esac
+
 echo [2 of 6] Creating certificate...
-openssl req -nodes -new -x509 -keyout callback.key -out callback.pem -days 720 -subj "//C=${certC}\CN=${certCN}\O=EFGS DEV Org"
+openssl req -nodes -new -x509 -keyout callback.key -out callback.pem -days 720 -subj "$certSubject"
 echo ... Certificate created.
 
 echo [3 of 6] Creating keystore...

--- a/tools/create_callback_client_certificate.sh
+++ b/tools/create_callback_client_certificate.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# fail on error
+set -e
+
 keystorefilename="efgs-cb-client.jks"
 keystorepassword="3fgs-p4ssw0rd"
 certCN="EFGS-Callback DEV"
@@ -6,10 +10,10 @@ certC="DE"
 yn=N
 
 ECHO [1 of 6] Deleting old files...
-rm callback.pem
-rm callback.key
-rm callback.p12
-rm ${keystorefilename}
+rm -f callback.pem
+rm -f callback.key
+rm -f callback.p12
+rm -f ${keystorefilename}
 echo ... old files deleted.
 read -p "keystorefilename [${keystorefilename}]:" input
 keystorefilename=${input:-${keystorefilename}}

--- a/tools/create_callback_client_certificate.sh
+++ b/tools/create_callback_client_certificate.sh
@@ -36,7 +36,7 @@ certC=${input:-${certC}}
 case "$(uname -s)" in
   MINGW32*|MSYS*|MINGW*)
     # Work around MinGW/MSYS's path conversion (http://www.mingw.org/wiki/Posix_path_conversion) 
-    ertSubject="//C=${certC}\CN=${certCN}\O=EFGS DEV Org"
+    certSubject="//C=${certC}\CN=${certCN}\O=EFGS DEV Org"
   ;;
   *)
     certSubject="/C=${certC}/CN=${certCN}/O=EFGS DEV Org"

--- a/tools/create_certificate_signature.bat
+++ b/tools/create_certificate_signature.bat
@@ -35,10 +35,8 @@ SET ISODATE=%ISODATE:T= %
 
 setlocal EnableDelayedExpansion
 
-SET RAW=
-FOR /f "tokens=*" %%i IN ('type %certFileName%') DO (
-    SET RAW=!RAW!%%i\n
-)
+openssl base64 -in %certFileName% -out cert.base64 -A
+SET /P CERT_BASE64=<cert.base64
 
 openssl x509 -fingerprint -sha256 -in %certFileName% -noout > HASH.txt
 SET /P HASH=<HASH.txt
@@ -65,7 +63,7 @@ IF %TYPEQ%==yes (
 )
 
 
-SET template=INSERT INTO certificate VALUES(NULL, '%ISODATE%', '%HASH%', '%COUNTRY%', '%TYPE%', FALSE, NULL, '%SIGNATURE%', '%RAW%');
+SET template=INSERT INTO certificate VALUES(NULL, '%ISODATE%', '%HASH%', '%COUNTRY%', '%TYPE%', FALSE, NULL, '%SIGNATURE%', FROM_BASE64('%CERT_BASE64%'));
 ECHO %template% > insert.sql
 
 ECHO [4 of 5] Insert statement created.

--- a/tools/create_certificate_signature.sh
+++ b/tools/create_certificate_signature.sh
@@ -24,8 +24,8 @@ openssl base64 -in sig.tmp -out signature.base64 -A
 echo ... saved to signature.base64
 signature=$(cat signature.base64)
 
-cert_raw=$(cat ${certFileName} | sed ':a;N;$!ba;s/\n/\\n/g')
-#echo $cert_raw
+cert_base64=$(cat ${certFileName} | base64)
+#echo $cert_base64
 
 openssl x509 -fingerprint -sha256 -in ${certFileName} -noout > fingerprint.sha256
 fingerprint=$(cat fingerprint.sha256)
@@ -49,7 +49,7 @@ purpose='SIGNING'
 fi
 
 
-template="INSERT INTO certificate VALUES(NULL, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', '$cert_raw\n')";
+template="INSERT INTO certificate VALUES(NULL, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', FROM_BASE64('$cert_base64'))";
 echo $template > insert.sql
 
 echo [4 of 4] Cleaning up...

--- a/tools/create_certificate_signature.sh
+++ b/tools/create_certificate_signature.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# fail on error
+set -e
+
 certFileName="client.pem"
 signCertFileName="trustanchor.key"
 signature=""

--- a/tools/create_trustanchor.bat
+++ b/tools/create_trustanchor.bat
@@ -7,7 +7,7 @@ SET /P "certC=Certificate Country [DE]: " || SET "certC=DE"
 
 ECHO [1 of 5] Deleting old files...
 DEL trustanchor.pem
-DEL trustanchor.pem
+DEL trustanchor.key
 DEL %keystorefilename%
 ECHO ... old files deleted.
 

--- a/tools/create_trustanchor.sh
+++ b/tools/create_trustanchor.sh
@@ -20,8 +20,18 @@ certCN=${input:-${certCN}}
 read -p "certC [${certC}]: " input
 certC=${input:-${certC}}
 
+case "$(uname -s)" in
+  MINGW32*|MSYS*|MINGW*)
+    # Work around MinGW/MSYS's path conversion (http://www.mingw.org/wiki/Posix_path_conversion) 
+    ertSubject="//C=${certC}\CN=${certCN}\O=TrustAnchor Dev Org"
+  ;;
+  *)
+    certSubject="/C=${certC}/CN=${certCN}/O=TrustAnchor Dev Org"
+  ;;
+esac
+
 echo [2 of 5] Creating certificate...
-openssl req -nodes -new -x509 -keyout trustanchor.key -out trustanchor.pem -days 720 -subj "//C=${certC}\CN=${certCN}\O=TrustAnchor Dev Org"
+openssl req -nodes -new -x509 -keyout trustanchor.key -out trustanchor.pem -days 720 -subj "$certSubject"
 echo ... Certificate created.
 
 echo [3 of 5] Creating keystore...

--- a/tools/create_trustanchor.sh
+++ b/tools/create_trustanchor.sh
@@ -10,7 +10,7 @@ certC="DE"
 
 echo [1 of 5] Deleting old files...
 rm -f trustanchor.pem
-rm -f trustanchor.pem
+rm -f trustanchor.key
 rm -f ${keystorefilename}
 echo ... old files deleted.
 

--- a/tools/create_trustanchor.sh
+++ b/tools/create_trustanchor.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+# fail on error
+set -e
+
 keystorefilename="efgs-ta.jks"
 keystorepassword="3fgs-p4ssw0rd"
 certCN="EFGS-TrustAnchor DEV"
 certC="DE"
 
 echo [1 of 5] Deleting old files...
-rm trustanchor.pem
-rm trustanchor.pem
-rm ${keystorefilename}
+rm -f trustanchor.pem
+rm -f trustanchor.pem
+rm -f ${keystorefilename}
 echo ... old files deleted.
 
 read -p "keystorefilename [${keystorefilename}]:" input


### PR DESCRIPTION
This PR fixes #242 and #244 and improves the bash scripts to fail on error. 