### PR TITLE
Callback: Request handling and transactional

### DIFF
--- a/src/main/java/eu/interop/federationgateway/service/CallbackTaskExecutorService.java
+++ b/src/main/java/eu/interop/federationgateway/service/CallbackTaskExecutorService.java
@@ -47,14 +47,15 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class CallbackTaskExecutorService {
 
-  private static final String MDC_PROP_TASK_ID = "taskId";
-  private static final String MDC_PROP_COUNTRY = "country";
-  private static final String MDC_PROP_CALLBACK_ID = "callbackId";
+  protected static final String MDC_PROP_TASK_ID = "taskId";
+  protected static final String MDC_PROP_COUNTRY = "country";
+  protected static final String MDC_PROP_CALLBACK_ID = "callbackId";
 
   private final EfgsProperties efgsProperties;
   private final WebClient webClient;
   private final CallbackService callbackService;
   private final CallbackTaskRepository callbackTaskRepository;
+  private final TransactionalCallbackTaskExecutorService transactionalCallbackTaskExecutorService;
 
   /**
    * Execute Callback processing.
@@ -66,7 +67,7 @@ public class CallbackTaskExecutorService {
     CallbackTaskEntity currentTask = getNextCallbackTask();
 
     while (currentTask != null) {
-      setExecutionLock(currentTask);
+      transactionalCallbackTaskExecutorService.setExecutionLock(currentTask);
       CallbackSubscriptionEntity subscription = currentTask.getCallbackSubscription();
 
       EfgsMdc.put(MDC_PROP_CALLBACK_ID, subscription.getCallbackId());
@@ -86,8 +87,8 @@ public class CallbackTaskExecutorService {
 
       if (callbackResult) {
         log.info("Successfully executed callback. Deleting callback task from database");
-        removeNotBeforeForNextTask(currentTask);
-        deleteTask(currentTask);
+        transactionalCallbackTaskExecutorService.removeNotBeforeForNextTask(currentTask);
+        transactionalCallbackTaskExecutorService.deleteTask(currentTask);
       } else {
         if (currentTask.getRetries() >= efgsProperties.getCallback().getMaxRetries()) {
           log.error("Callback reached max amount of retries. Deleting callback subscription.");
@@ -97,25 +98,13 @@ public class CallbackTaskExecutorService {
           currentTask.setRetries(currentTask.getRetries() + 1);
           currentTask.setLastTry(ZonedDateTime.now(ZoneOffset.UTC));
 
-          removeExecutionLock(currentTask);
+          transactionalCallbackTaskExecutorService.removeExecutionLock(currentTask);
         }
       }
       EfgsMdc.clear();
       currentTask = getNextCallbackTask();
     }
     log.info("Callback processing finished.");
-  }
-
-  private void removeNotBeforeForNextTask(CallbackTaskEntity currentTask) {
-    callbackTaskRepository.findFirstByNotBeforeIs(currentTask).ifPresent(task -> {
-      EfgsMdc.put(MDC_PROP_CALLBACK_ID, currentTask.getCallbackSubscription().getCallbackId());
-      EfgsMdc.put(MDC_PROP_COUNTRY, currentTask.getCallbackSubscription().getCountry());
-
-      log.info("Removing notBefore restriction from CallbackTask.");
-
-      task.setNotBefore(null);
-      callbackTaskRepository.save(task);
-    });
   }
 
   boolean sendCallback(CallbackTaskEntity callbackTask) {
@@ -157,44 +146,6 @@ public class CallbackTaskExecutorService {
     }
 
     return false;
-  }
-
-  /**
-   * Deletes a CallbackTaskEntity from database.
-   *
-   * @param task the task that has to be deleted.
-   */
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
-  void deleteTask(CallbackTaskEntity task) {
-    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
-    log.info("Deleting CallbackTask from db");
-    callbackTaskRepository.delete(task);
-  }
-
-  /**
-   * Sets execution lock for given task so that no other instance will work on this task.
-   *
-   * @param task The task to be locked.
-   */
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
-  void setExecutionLock(CallbackTaskEntity task) {
-    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
-    log.info("Setting execution lock for CallbackTask");
-    task.setExecutionLock(ZonedDateTime.now(ZoneOffset.UTC));
-    callbackTaskRepository.save(task);
-  }
-
-  /**
-   * Removes execution lock from task.
-   *
-   * @param task the task.
-   */
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
-  void removeExecutionLock(CallbackTaskEntity task) {
-    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
-    log.info("Removing execution lock for CallbackTask.");
-    task.setExecutionLock(null);
-    callbackTaskRepository.save(task);
   }
 
   private CallbackTaskEntity getNextCallbackTask() {

--- a/src/main/java/eu/interop/federationgateway/service/TransactionalCallbackTaskExecutorService.java
+++ b/src/main/java/eu/interop/federationgateway/service/TransactionalCallbackTaskExecutorService.java
@@ -1,0 +1,99 @@
+/*-
+ * ---license-start
+ * EU-Federation-Gateway-Service / efgs-federation-gateway
+ * ---
+ * Copyright (C) 2020 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package eu.interop.federationgateway.service;
+
+import static eu.interop.federationgateway.service.CallbackTaskExecutorService.MDC_PROP_CALLBACK_ID;
+import static eu.interop.federationgateway.service.CallbackTaskExecutorService.MDC_PROP_COUNTRY;
+import static eu.interop.federationgateway.service.CallbackTaskExecutorService.MDC_PROP_TASK_ID;
+
+import eu.interop.federationgateway.entity.CallbackTaskEntity;
+import eu.interop.federationgateway.repository.CallbackTaskRepository;
+import eu.interop.federationgateway.utils.EfgsMdc;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TransactionalCallbackTaskExecutorService {
+
+  private final CallbackTaskRepository callbackTaskRepository;
+
+  /**
+   * Queries the database for the following task of a CallbackTaskEntity and removes the notBefore property.
+   *
+   * @param currentTask the tasks the following should be searched for.
+   */
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  void removeNotBeforeForNextTask(CallbackTaskEntity currentTask) {
+    callbackTaskRepository.findFirstByNotBeforeIs(currentTask).ifPresent(task -> {
+      EfgsMdc.put(MDC_PROP_CALLBACK_ID, currentTask.getCallbackSubscription().getCallbackId());
+      EfgsMdc.put(MDC_PROP_COUNTRY, currentTask.getCallbackSubscription().getCountry());
+
+      log.info("Removing notBefore restriction from CallbackTask.");
+
+      task.setNotBefore(null);
+      callbackTaskRepository.save(task);
+    });
+  }
+
+  /**
+   * Deletes a CallbackTaskEntity from database.
+   *
+   * @param task the task that has to be deleted.
+   */
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  void deleteTask(CallbackTaskEntity task) {
+    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
+    log.info("Deleting CallbackTask from db");
+    callbackTaskRepository.delete(task);
+  }
+
+  /**
+   * Sets execution lock for given task so that no other instance will work on this task.
+   *
+   * @param task The task to be locked.
+   */
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  void setExecutionLock(CallbackTaskEntity task) {
+    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
+    log.info("Setting execution lock for CallbackTask");
+    task.setExecutionLock(ZonedDateTime.now(ZoneOffset.UTC));
+    callbackTaskRepository.save(task);
+  }
+
+  /**
+   * Removes execution lock from task.
+   *
+   * @param task the task.
+   */
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  void removeExecutionLock(CallbackTaskEntity task) {
+    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
+    log.info("Removing execution lock for CallbackTask.");
+    task.setExecutionLock(null);
+    callbackTaskRepository.save(task);
+  }
+}

--- a/src/test/java/eu/interop/federationgateway/service/CallbackTaskExecutorServiceTest.java
+++ b/src/test/java/eu/interop/federationgateway/service/CallbackTaskExecutorServiceTest.java
@@ -128,8 +128,11 @@ public class CallbackTaskExecutorServiceTest {
     Mockito.doReturn(true)
       .when(callbackServiceMock).checkUrl(Mockito.anyString(), Mockito.anyString());
 
+    TransactionalCallbackTaskExecutorService tctes =
+      new TransactionalCallbackTaskExecutorService(callbackTaskRepository);
+
     callbackTaskExecutorService = new CallbackTaskExecutorService(
-      efgsProperties, webClient, callbackServiceMock, callbackTaskRepository);
+      efgsProperties, webClient, callbackServiceMock, callbackTaskRepository, tctes);
   }
 
   @After


### PR DESCRIPTION
This PR adresses tickets #248  and #247 

The handling of requests in CallbackTaskExecutor is switched from .exchange to .retrieve. Also the transactional methods are now in a seperate class so that the @Transactional annotation has a real effect.