### PR TITLE
Shedlock for DiagnosisKeyCleanup and CallbackTaskCleanup

### DIFF
--- a/src/main/java/eu/interop/federationgateway/service/CallbackTaskCleanupService.java
+++ b/src/main/java/eu/interop/federationgateway/service/CallbackTaskCleanupService.java
@@ -25,6 +25,7 @@ import eu.interop.federationgateway.utils.EfgsMdc;
 import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -42,6 +43,8 @@ public class CallbackTaskCleanupService {
    * Removes periodically the execution locks from abandoned tasks.
    */
   @Scheduled(fixedDelay = 60000)
+  @SchedulerLock(name = "CallbackTaskCleanupService_deleteAbandonedLocks", lockAtLeastFor = "PT0S",
+    lockAtMostFor = "${efgs.callback.locklimit}")
   public void deleteAbandonedLocks() {
     log.info("Deleting task locks of abandoned tasks");
 

--- a/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyCleanupService.java
+++ b/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyCleanupService.java
@@ -27,6 +27,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -45,6 +46,8 @@ public class DiagnosisKeyCleanupService {
    * Cleanup task to delete all DiagnosisKeys and DiagnosisKeyBatches which are older then configured.
    */
   @Scheduled(cron = "0 0 0 * * *")
+  @SchedulerLock(name = "DiagnosisKeyCleanupService_cleanupDiagnosisKeys", lockAtLeastFor = "PT0S",
+    lockAtMostFor = "${efgs.download-settings.locklimit}")
   public void cleanupDiagnosisKeys() {
     ZonedDateTime deleteTimestamp = LocalDate.ofInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC)
       .atStartOfDay(ZoneOffset.UTC)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ efgs:
     keyStorePass: 3fgs-p4ssw0rd
     certificateAlias: efgs_trust_anchor
   callback:
+    locklimit: 1800000
     keyStorePath: /ec/prod/app/san/efgs/efgs-cb-client.jks
     keyStorePass: 3fgs-p4ssw0rd
     keyStorePrivateKeyAlias: efgs_callback_key
@@ -48,6 +49,7 @@ efgs:
   upload-settings:
     maximum-upload-batch-size: 5000
   download-settings:
+    locklimit: 1800000
     max-age-in-days: 6
   cert-auth:
     header-fields:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,7 @@ efgs:
     keyStorePass: 3fgs-p4ssw0rd
     certificateAlias: efgs_trust_anchor
   callback:
+    locklimit: 1800000
     keyStorePath: keystore/efgs-cb-client.jks
     keyStorePass: 3fgs-p4ssw0rd
     keyStorePrivateKeyAlias: efgs_callback_key
@@ -47,6 +48,7 @@ efgs:
   upload-settings:
     maximum-upload-batch-size: 5000
   download-settings:
+    locklimit: 1800000
     max-age-in-days: 14
   cert-auth:
     header-fields:


### PR DESCRIPTION
Added a Shedlock config for DiagnosisKeyCleanupJob and CallbackTaskCleanupJob to prevent missleading error messages.

This PR closes #234 