### PR TITLE
fix: TrustAnchor up to 4096 bit key size

### DIFF
--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -35,5 +35,8 @@ databaseChangeLog:
   - include:
       file: changelog/v002-update-diagnosiskeypayload_visitedCountries.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/v001-change-certificate-signature-column-size.yml
+      relativeToChangelogFile: true
 
 

--- a/src/main/resources/db/changelog/v001-change-certificate-signature-column-size.yml
+++ b/src/main/resources/db/changelog/v001-change-certificate-signature-column-size.yml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: change-certificate-signature-column-size
+      author: f11h
+      changes:
+        - modifyDataType:
+            tableName: certificate
+            columnName: signature
+            newDataType: varchar(690)
+

--- a/src/test/java/eu/interop/federationgateway/TestData.java
+++ b/src/test/java/eu/interop/federationgateway/TestData.java
@@ -225,7 +225,7 @@ public class TestData {
     OperatorCreationException {
     if (TestData.keyPair == null) {
       KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-      keyGen.initialize(2048);
+      keyGen.initialize(4096);
       TestData.keyPair = keyGen.generateKeyPair();
     }
 


### PR DESCRIPTION
Increased size of certificate signature column to support trust anchors with private key with up to 4096 bit key size.

closes #217 