### PR TITLE
fix: document-unique-upload-batchtag

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -282,12 +282,12 @@
         "parameters": [{
             "name": "batchTag",
             "in": "header",
-            "description": "Required Tag to tag the send batch (must be not unique).",
+            "description": "Required Tag to tag the send batch (must be unique).",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "example": "20200731-1"
+            "example": "20200731-1, or a hash"
           }, {
             "name": "batchSignature",
             "in": "header",

--- a/src/main/java/eu/interop/federationgateway/controller/UploadController.java
+++ b/src/main/java/eu/interop/federationgateway/controller/UploadController.java
@@ -89,8 +89,8 @@ public class UploadController {
         name = "batchTag",
         in = ParameterIn.HEADER,
         required = true,
-        description = "Required Tag to tag the send batch (must be not unique).",
-        example = "20200731-1"
+        description = "Required Tag to tag the send batch (must be unique).",
+        example = "20200731-1, or a hash"
       ),
       @Parameter(
         name = "batchSignature",


### PR DESCRIPTION
Updated documents for more clearness on how to name batchtags.
The batchtags must be unique systemwide. A common proceed to achieve this would be to prefix or attach a hash value or the country initials.