### PR TITLE
Better Postgres-Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>

--- a/src/main/docker/docker-compose.override.yml
+++ b/src/main/docker/docker-compose.override.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql/mysql-server:5.7
+    container_name: efgs-federation-gateway-mysql
+    environment:
+      - MYSQL_DATABASE=fg
+      - MYSQL_ROOT_PASSWORD=admin
+      - MYSQL_USER=fg_adm
+      - MYSQL_PASSWORD=admin
+    networks:
+      persistence:
+        aliases:
+          - mysql
+  backend:
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=mysql
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/fg
+    depends_on:
+      - mysql

--- a/src/main/docker/docker-compose.psql.yml
+++ b/src/main/docker/docker-compose.psql.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  psql:
+    image: postgres:10
+    environment:
+      - POSTGRES_USER=fg_adm
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_DB=fg
+    networks:
+      persistence:
+        aliases:
+          - psql
+  backend:
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=psql
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://psql:5432/fg
+    depends_on:
+      - psql

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,38 +1,19 @@
 version: '3'
 
 services:
-  mysql:
-    image: mysql/mysql-server:5.7
-    container_name: efgs-federation-gateway-mysql
-    ports:
-      - 3306:3306
-    environment:
-      - MYSQL_DATABASE=fg
-      - MYSQL_ROOT_PASSWORD=admin
-      - MYSQL_USER=fg_adm
-      - MYSQL_PASSWORD=admin
-    networks:
-      persistence:
-        aliases:
-          - mysql
-
   backend:
     build: .
     image: efgs-federation-gateway/backend
     container_name: efgs-federation-gateway-backend
-    volumes:
-      - ./certs:/ec/prod/app/san/efgs
-    ports:
-      - 8080:8080
     environment:
-      - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=mysql
-      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/fg
       - SPRING_DATASOURCE_USERNAME=fg_adm
       - SPRING_DATASOURCE_PASSWORD=admin
       - efgs_dbencryption_password=aaaaaaaaaaaaaaaa
-    depends_on:
-      - mysql
+    volumes:
+      - ./certs:/ec/prod/app/san/efgs
+      - ./logs:/logs
+    ports:
+      - 8080:8080
     networks:
       backend:
       persistence:

--- a/src/main/resources/application-psql.yml
+++ b/src/main/resources/application-psql.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:3306/fg
+    username: sa
+    password: sa
+    driver-class-name: org.postgresql.Driver
+    jndi-name: false
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+  liquibase:
+    contexts: 'psql'

--- a/src/main/resources/db/changelog/v000-create-callback-subscription-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-callback-subscription-entity-table.yml
@@ -37,6 +37,7 @@ databaseChangeLog:
   - changeSet:
       id: create-callback-subscription-entity-table-increment
       author: f11h
+      context: '!psql'
       changes:
         - addAutoIncrement:
             tableName: callback_subscription

--- a/src/main/resources/db/changelog/v000-create-callback-task-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-callback-task-entity-table.yml
@@ -58,6 +58,7 @@ databaseChangeLog:
   - changeSet:
       id: create-callback-task-entity-table-increment
       author: f11h
+      context: '!psql'
       changes:
         - addAutoIncrement:
             tableName: callback_task

--- a/src/main/resources/db/changelog/v000-create-certificate-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-certificate-entity-table.yml
@@ -46,6 +46,7 @@ databaseChangeLog:
   - changeSet:
       id: create-certificate-entity-table-increment
       author: f11h
+      context: '!psql'
       changes:
         - addAutoIncrement:
             tableName: certificate


### PR DESCRIPTION
This PR is an updated version of https://github.com/eu-federation-gateway-service/efgs-federation-gateway/pull/245. 

As in the migrations, the `autoIncrement` is added twice in the same migration, and Postgres (and maybe other Database-Languages?) don't like that, we now use the [`context`](https://docs.liquibase.com/concepts/advanced/contexts.html) tag to control the application of said migration. 

According to a blog post from 2009 ([https://www.liquibase.org/blog/what-affects-changeset-checksums](https://www.liquibase.org/blog/what-affects-changeset-checksums)), the `context` Tag on the `changeSet` field should not modify the checksum, and hence should not break existing systems, where the migrations was already applied. I also shortly looked at the code base on github and looking at the [ChangeSet](https://github.com/liquibase/liquibase/blob/43ed0e54adedc5f12c7933b998550e777d9b683d/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java#L284) class, it still seems to be the case.

Further, the docker-compose setup was adjusted, to allow for multiple different configs using [shared compose-files](https://docs.docker.com/compose/extends/#multiple-compose-files). The default behaviour - using `docker-compose up --build` as described in the `README` should not be any different, but with `docker-compose -f docker-compose.yml -f docker-compose.psql.yml up --build` the postgres configuration can now be used.

Further, the `mysql` service in the `Dockerfile` was adjusted to __not__ automatically expose the database port to the host, as this can pose a security risk (if overseen in production), and also can fail, if the host is already running a native `mysql` DB or any other service that binds to port `3306`, leading to unnecessary pitfalls when trying to run the container .

On the other hand, the default configuration now includes a bind mount to the current folder to actually be able to see the log files, without changing the configuration.

Last but not least, the `POM`-File now includes a runtime dependency to the postgres db-connector.