### PR TITLE
fix: Removed unnecessary auto increment changesets

### DIFF
--- a/src/main/resources/db/changelog/v000-create-callback-subscription-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-callback-subscription-entity-table.yml
@@ -34,13 +34,3 @@ databaseChangeLog:
                   type: varchar(2)
                   constraints:
                     nullable: false
-  - changeSet:
-      id: create-callback-subscription-entity-table-increment
-      author: f11h
-      changes:
-        - addAutoIncrement:
-            tableName: callback_subscription
-            columnName: id
-            columnDataType: bigint
-            startWith: 1
-            incrementBy: 1

--- a/src/main/resources/db/changelog/v000-create-callback-task-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-callback-task-entity-table.yml
@@ -55,13 +55,3 @@ databaseChangeLog:
                     nullable: false
                     foreignKeyName: fk_callbacktask_callbacksubscription
                     references: callback_subscription(id)
-  - changeSet:
-      id: create-callback-task-entity-table-increment
-      author: f11h
-      changes:
-        - addAutoIncrement:
-            tableName: callback_task
-            columnName: id
-            columnDataType: bigint
-            startWith: 1
-            incrementBy: 1

--- a/src/main/resources/db/changelog/v000-create-certificate-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-certificate-entity-table.yml
@@ -43,13 +43,3 @@ databaseChangeLog:
                   type: varchar(256)
                   constraints:
                     nullable: true
-  - changeSet:
-      id: create-certificate-entity-table-increment
-      author: f11h
-      changes:
-        - addAutoIncrement:
-            tableName: certificate
-            columnName: id
-            columnDataType: bigint
-            startWith: 1
-            incrementBy: 1


### PR DESCRIPTION
The explicit auto increment changeset is not needed as long as we have a
```
  autoincrement: true
```
constraint on the id fields.

Deleting the whole changeset does not affect existing databases, so it is safe to remove it.