### PR TITLE
Add Postgres Example to community branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>

--- a/src/main/docker/docker-compose.override.yml
+++ b/src/main/docker/docker-compose.override.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql/mysql-server:5.7
+    container_name: efgs-federation-gateway-mysql
+    environment:
+      - MYSQL_DATABASE=fg
+      - MYSQL_ROOT_PASSWORD=admin
+      - MYSQL_USER=fg_adm
+      - MYSQL_PASSWORD=admin
+    networks:
+      persistence:
+        aliases:
+          - mysql
+  backend:
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=mysql
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/fg
+    depends_on:
+      - mysql

--- a/src/main/docker/docker-compose.psql.yml
+++ b/src/main/docker/docker-compose.psql.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  psql:
+    image: postgres:10
+    environment:
+      - POSTGRES_USER=fg_adm
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_DB=fg
+    networks:
+      persistence:
+        aliases:
+          - psql
+  backend:
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=psql
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://psql:5432/fg
+    depends_on:
+      - psql

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,38 +1,19 @@
 version: '3'
 
 services:
-  mysql:
-    image: mysql/mysql-server:5.7
-    container_name: efgs-federation-gateway-mysql
-    ports:
-      - 3306:3306
-    environment:
-      - MYSQL_DATABASE=fg
-      - MYSQL_ROOT_PASSWORD=admin
-      - MYSQL_USER=fg_adm
-      - MYSQL_PASSWORD=admin
-    networks:
-      persistence:
-        aliases:
-          - mysql
-
   backend:
     build: .
     image: efgs-federation-gateway/backend
     container_name: efgs-federation-gateway-backend
-    volumes:
-      - ./certs:/ec/prod/app/san/efgs
-    ports:
-      - 8080:8080
     environment:
-      - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=mysql
-      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/fg
       - SPRING_DATASOURCE_USERNAME=fg_adm
       - SPRING_DATASOURCE_PASSWORD=admin
       - efgs_dbencryption_password=aaaaaaaaaaaaaaaa
-    depends_on:
-      - mysql
+    volumes:
+      - ./certs:/ec/prod/app/san/efgs
+      - ./logs:/logs
+    ports:
+      - 8080:8080
     networks:
       backend:
       persistence:

--- a/src/main/resources/application-psql.yml
+++ b/src/main/resources/application-psql.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:3306/fg
+    username: sa
+    password: sa
+    driver-class-name: org.postgresql.Driver
+    jndi-name: false
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect

--- a/src/main/resources/db/changelog/v000-create-callback-subscription-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-callback-subscription-entity-table.yml
@@ -34,13 +34,3 @@ databaseChangeLog:
                   type: varchar(2)
                   constraints:
                     nullable: false
-  - changeSet:
-      id: create-callback-subscription-entity-table-increment
-      author: f11h
-      changes:
-        - addAutoIncrement:
-            tableName: callback_subscription
-            columnName: id
-            columnDataType: bigint
-            startWith: 1
-            incrementBy: 1

--- a/src/main/resources/db/changelog/v000-create-callback-task-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-callback-task-entity-table.yml
@@ -55,13 +55,3 @@ databaseChangeLog:
                     nullable: false
                     foreignKeyName: fk_callbacktask_callbacksubscription
                     references: callback_subscription(id)
-  - changeSet:
-      id: create-callback-task-entity-table-increment
-      author: f11h
-      changes:
-        - addAutoIncrement:
-            tableName: callback_task
-            columnName: id
-            columnDataType: bigint
-            startWith: 1
-            incrementBy: 1

--- a/src/main/resources/db/changelog/v000-create-certificate-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-certificate-entity-table.yml
@@ -43,13 +43,3 @@ databaseChangeLog:
                   type: varchar(256)
                   constraints:
                     nullable: true
-  - changeSet:
-      id: create-certificate-entity-table-increment
-      author: f11h
-      changes:
-        - addAutoIncrement:
-            tableName: certificate
-            columnName: id
-            columnDataType: bigint
-            startWith: 1
-            incrementBy: 1


### PR DESCRIPTION
Since the EFGS does not officially support postgres, we split https://github.com/eu-federation-gateway-service/efgs-federation-gateway/pull/257 into a `database-agnostic` [fix](https://github.com/eu-federation-gateway-service/efgs-federation-gateway/pull/258), which removed the duplication of `autoIncrement`, and this PR, a  postgres specific one.

In this PR we add the postgres connector to the `POM.xml`, splitted the `docker-compose.yml` to allow the use of shared docker files and added a basic example `application-psql.yml`, which exposes the `psql` profile to spring.

In order to build and run the `docker-compose` with postgres use `docker-compose -f docker-compose.yml -f docker-compose.psql.yml up --build`.