### PR TITLE
Little Improvement of Transaction Handling

### DIFF
--- a/src/main/java/eu/interop/federationgateway/service/CallbackTaskExecutorService.java
+++ b/src/main/java/eu/interop/federationgateway/service/CallbackTaskExecutorService.java
@@ -87,8 +87,7 @@ public class CallbackTaskExecutorService {
 
       if (callbackResult) {
         log.info("Successfully executed callback. Deleting callback task from database");
-        transactionalCallbackTaskExecutorService.removeNotBeforeForNextTask(currentTask);
-        transactionalCallbackTaskExecutorService.deleteTask(currentTask);
+        transactionalCallbackTaskExecutorService.removeNotBeforeForNextTaskAndDeleteTask(currentTask);
       } else {
         if (currentTask.getRetries() >= efgsProperties.getCallback().getMaxRetries()) {
           log.error("Callback reached max amount of retries. Deleting callback subscription.");

--- a/src/main/java/eu/interop/federationgateway/service/TransactionalCallbackTaskExecutorService.java
+++ b/src/main/java/eu/interop/federationgateway/service/TransactionalCallbackTaskExecutorService.java
@@ -47,7 +47,7 @@ public class TransactionalCallbackTaskExecutorService {
    * @param currentTask the tasks the following should be searched for.
    */
   @Transactional(Transactional.TxType.REQUIRES_NEW)
-  void removeNotBeforeForNextTask(CallbackTaskEntity currentTask) {
+  void removeNotBeforeForNextTaskAndDeleteTask(CallbackTaskEntity currentTask) {
     callbackTaskRepository.findFirstByNotBeforeIs(currentTask).ifPresent(task -> {
       EfgsMdc.put(MDC_PROP_CALLBACK_ID, currentTask.getCallbackSubscription().getCallbackId());
       EfgsMdc.put(MDC_PROP_COUNTRY, currentTask.getCallbackSubscription().getCountry());
@@ -57,18 +57,9 @@ public class TransactionalCallbackTaskExecutorService {
       task.setNotBefore(null);
       callbackTaskRepository.save(task);
     });
-  }
 
-  /**
-   * Deletes a CallbackTaskEntity from database.
-   *
-   * @param task the task that has to be deleted.
-   */
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
-  void deleteTask(CallbackTaskEntity task) {
-    EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
     log.info("Deleting CallbackTask from db");
-    callbackTaskRepository.delete(task);
+    callbackTaskRepository.delete(currentTask);
   }
 
   /**
@@ -76,7 +67,6 @@ public class TransactionalCallbackTaskExecutorService {
    *
    * @param task The task to be locked.
    */
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
   void setExecutionLock(CallbackTaskEntity task) {
     EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
     log.info("Setting execution lock for CallbackTask");
@@ -89,7 +79,6 @@ public class TransactionalCallbackTaskExecutorService {
    *
    * @param task the task.
    */
-  @Transactional(Transactional.TxType.REQUIRES_NEW)
   void removeExecutionLock(CallbackTaskEntity task) {
     EfgsMdc.put(MDC_PROP_TASK_ID, task.getId());
     log.info("Removing execution lock for CallbackTask.");


### PR DESCRIPTION
The transaction handling of callback handling was not optimal.

The "Not-Before"-constraint removal and the deletion of current task was in two transactions. This makes no sense. So now these to steps are merged into one transaction.