### PR TITLE
fix: Memory Optimization and ThreadPool for Scheduled Jobs

### DIFF
--- a/src/main/java/eu/interop/federationgateway/repository/DiagnosisKeyBatchRepository.java
+++ b/src/main/java/eu/interop/federationgateway/repository/DiagnosisKeyBatchRepository.java
@@ -25,6 +25,8 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 public interface DiagnosisKeyBatchRepository extends JpaRepository<DiagnosisKeyBatchEntity, Long> {
 
   @Modifying
-  int deleteByCreatedAtBefore(ZonedDateTime before);
+  @Query("DELETE FROM DiagnosisKeyBatchEntity d WHERE d.createdAt < :before")
+  int deleteByCreatedAtBefore(@Param("before") ZonedDateTime before);
 
   Optional<DiagnosisKeyBatchEntity> findByBatchName(String name);
 

--- a/src/main/java/eu/interop/federationgateway/repository/DiagnosisKeyEntityRepository.java
+++ b/src/main/java/eu/interop/federationgateway/repository/DiagnosisKeyEntityRepository.java
@@ -36,7 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 public interface DiagnosisKeyEntityRepository extends JpaRepository<DiagnosisKeyEntity, Long> {
 
   @Modifying
-  int deleteByCreatedAtBefore(ZonedDateTime before);
+  @Query("DELETE FROM DiagnosisKeyEntity d WHERE d.createdAt < :before")
+  int deleteByCreatedAtBefore(@Param("before") ZonedDateTime before);
 
   List<DiagnosisKeyEntity> findAllByPayloadOrigin(String country);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
   liquibase:
     enabled: true
     change-log: classpath:db/changelog.yml
+  task:
+    scheduling:
+      pool:
+        size: 5
 management:
   endpoints:
     web:


### PR DESCRIPTION
**Memory Optimization**: Deleting Diagnosis keys always resulted in loading alle keys to be deleted into heap. This can cause a OutOfMemoryException.
To avoid this the deleting of DiagnosisKeys and DiagnosisKeyBatches has been changed to direct querys.

**Thread Pool Scheduled Jobs**: Springs default ThreadPool-Size for scheduled jobs is 1. As long as EFGS has some background jobs which are executed regulary we increased the ThreadPool-Size for better load balancing.

This could have a positive effect for #262 
