### PR TITLE
Dependency Update Spring Boot 2.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,28 +25,28 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- dependencies -->
-    <owasp.version>6.0.5</owasp.version>
-    <spring.boot.version>2.4.1</spring.boot.version>
-    <spring.cloud.version>2020.0.0</spring.cloud.version>
-    <spring.test.version>5.3.2</spring.test.version>
-    <spring.security.version>5.4.2</spring.security.version>
-    <lombok.version>1.18.16</lombok.version>
-    <liquibase.version>4.2.2</liquibase.version>
-    <springdoc.version>1.5.2</springdoc.version>
-    <protobuf.version>3.14.0</protobuf.version>
+    <owasp.version>6.1.1</owasp.version>
+    <spring.boot.version>2.4.3</spring.boot.version>
+    <spring.cloud.version>2020.0.1</spring.cloud.version>
+    <spring.test.version>5.3.4</spring.test.version>
+    <spring.security.version>5.4.5</spring.security.version>
+    <lombok.version>1.18.18</lombok.version>
+    <liquibase.version>4.3.1</liquibase.version>
+    <springdoc.version>1.5.4</springdoc.version>
+    <protobuf.version>3.15.1</protobuf.version>
     <protobuf-format.version>1.4</protobuf-format.version>
-    <junit.version>5.7.0</junit.version>
-    <mapstruct.version>1.4.1.Final</mapstruct.version>
-    <mockito.version>3.7.0</mockito.version>
+    <junit.version>5.7.1</junit.version>
+    <mapstruct.version>1.4.2.Final</mapstruct.version>
+    <mockito.version>3.7.7</mockito.version>
     <bcpkix.version>1.68</bcpkix.version>
     <reactor.version>1.0.1.RELEASE</reactor.version>
-    <okhttp.version>4.9.0</okhttp.version>
+    <okhttp.version>4.9.1</okhttp.version>
     <shedlock.version>4.20.0</shedlock.version>
     <!-- plugins -->
-    <plugin.checkstyle.version>3.1.1</plugin.checkstyle.version>
+    <plugin.checkstyle.version>3.1.2</plugin.checkstyle.version>
     <plugin.sonar.version>3.6.1.1688</plugin.sonar.version>
     <plugin.jacoco.version>0.8.6</plugin.jacoco.version>
-    <plugin.os-maven.version>1.6.2</plugin.os-maven.version>
+    <plugin.os-maven.version>1.7.0</plugin.os-maven.version>
     <plugin.surefire.version>3.0.0-M5</plugin.surefire.version>
     <!-- license -->
     <license.projectName>EU-Federation-Gateway-Service / efgs-federation-gateway</license.projectName>


### PR DESCRIPTION
Updated dependencies:

Spring Boot: 2.4.1 --> 2.4.3
Spring Cloud: 2020.0.0 --> 2020.0.1
Spring Security: 5.4.2 --> 5.4.5
Lombok: 1.18.16 --> 1.18.18
Liquibase: 4.2.2 --> 4.3.1
SpringDoc: 1.5.2 --> 1.5.4
Mapstruct: 14.1.Final --> 1.4.2.Final
okhttp: 4.9.0 --> 4.9.1

Test
JUnit: 5.7.0 --> 5.7.1
Mockito: 3.7.0 --> 3.7.7
Spring Test: 5.3.2 --> 5.3.4

Plugins
owasp: 6.0.5 --> 6.1.1
checkstyle: 3.1.1 --> 3.1.2
OS-Maven: 1.6.2 --> 1.7.0