### PR TITLE
Duplicate key handling without rollback

### DIFF
--- a/src/main/java/eu/interop/federationgateway/repository/DiagnosisKeyEntityRepository.java
+++ b/src/main/java/eu/interop/federationgateway/repository/DiagnosisKeyEntityRepository.java
@@ -62,4 +62,9 @@ public interface DiagnosisKeyEntityRepository extends JpaRepository<DiagnosisKey
     @Param("uploaderBatchTags") List<String> uploaderBatchTags,
     @Param("batchTag") String batchTag);
 
+
+  @Query("SELECT t "
+    + "FROM DiagnosisKeyEntity t WHERE payloadHash IN :payloadHashes")
+ List<DiagnosisKeyEntity> getDiagnosisKeysByPayloadHashes(@Param("payloadHashes") List<String> payloadHashes);
+
 }

--- a/src/test/java/eu/interop/federationgateway/controller/UploadControllerTest.java
+++ b/src/test/java/eu/interop/federationgateway/controller/UploadControllerTest.java
@@ -214,6 +214,7 @@ public class UploadControllerTest {
     bytesToSign = BatchSignatureUtilsTest.createBytesToSign(batch2);
     String signatureBatch2 = signatureGenerator.sign(bytesToSign, TestData.validCertificate);
 
+    // The first upload request should successfully insert key1 and report it as HTTP 201 (created).
     mockMvc.perform(post("/diagnosiskeys/upload")
       .contentType("application/protobuf; version=1.0")
       .header("batchTag", TestData.FIRST_BATCHTAG)
@@ -223,6 +224,8 @@ public class UploadControllerTest {
       .content(batch1.toByteArray())
     ).andExpect(status().isCreated());
 
+    // The second upload request should report one conflict (key1 as 409) and
+    // one insert (key2 as 201).
     mockMvc.perform(post("/diagnosiskeys/upload")
       .contentType("application/protobuf; version=1.0")
       .header("batchTag", TestData.SECOND_BATCHTAG)
@@ -233,7 +236,8 @@ public class UploadControllerTest {
     )
       .andExpect(status().isMultiStatus())
       .andExpect(result -> {
-        Assert.assertEquals(1, diagnosisKeyEntityRepository.count());
+        // According to the backend response(s) there should be two keys in the database now.
+        Assert.assertEquals(2, diagnosisKeyEntityRepository.count());
 
         JsonParser jsonParser = JsonParserFactory.getJsonParser();
         Map<String, Object> map = jsonParser.parseMap(result.getResponse().getContentAsString());


### PR DESCRIPTION
This PR fixes https://github.com/eu-federation-gateway-service/efgs-federation-gateway/issues/269. 

- Fix and extend unit test of duplicate key handling
- Avoid database rollback when upload contains duplicate keys:
By finding and filtering duplicates (conflicts) before inserting them
into the database, we avoid triggering a rollback of the transaction.
Additionally, we need to tell the @transaction not to rollback on
`DiagnosisKeyDuplicateInsertException`'s, which are triggered when
duplicates were detected.
In case of exceptions while trying to INSERT a key into the database,
we have to assume a rollback on database level will be triggered and
therefore report all keys as failed (empty 201 list).