### PR TITLE
Add MySQL and PGSGL templates for insert queries

### DIFF
--- a/tools/create_certificate_signature.sh
+++ b/tools/create_certificate_signature.sh
@@ -49,8 +49,13 @@ purpose='SIGNING'
 fi
 
 
-template="INSERT INTO certificate VALUES(NULL, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', FROM_BASE64('$cert_base64'))";
-echo $template > insert.sql
+#Postgres DB-Query template
+template_pgsql="INSERT INTO certificate VALUES(DEFAULT, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', convert_from(decode('$cert_base64', 'base64'), 'utf-8'))";
+echo $template_pgsql > template_pgsql.sql
+
+#Mysql DB-Query template
+template_mysql="INSERT INTO certificate VALUES(NULL, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', FROM_BASE64('$cert_base64'))";
+echo $template_mysql > template_mysql.sql
 
 echo [4 of 4] Cleaning up...
 rm sig.tmp


### PR DESCRIPTION
We now generate two query templates, one for MySQL and one for PostgreSQL.

Man differences:

- PostgreSQL does not allow inserting `NULL` for non null values -> use `DEFAULT` instead
- PostgreSQL does not have a `FROM_BASE64` function, replace it with `convert_from` and `decode`