### PR TITLE
Use OpenSSL Base64 Encoding for Calculating Certificate Hash

### DIFF
--- a/tools/create_certificate_signature.sh
+++ b/tools/create_certificate_signature.sh
@@ -24,7 +24,7 @@ openssl base64 -in sig.tmp -out signature.base64 -A
 echo ... saved to signature.base64
 signature=$(cat signature.base64)
 
-cert_base64=$(cat ${certFileName} | base64)
+cert_base64=$(cat ${certFileName} | openssl base64 -A)
 #echo $cert_base64
 
 openssl x509 -fingerprint -sha256 -in ${certFileName} -noout > fingerprint.sha256


### PR DESCRIPTION
This unifies base64 encoding on all platforms.

MacOSX/BSD variants of `base64` encode strings on one line, whereas other implementations default to block encoding. Since the utilities are different we now use the `openssl` utility, which is used anyways, to base64 encode on one line, with the `-A` flag.