### PR TITLE
Allow hash calculation for full-certificate

### DIFF
--- a/src/main/java/eu/interop/federationgateway/config/EfgsProperties.java
+++ b/src/main/java/eu/interop/federationgateway/config/EfgsProperties.java
@@ -104,6 +104,8 @@ public class EfgsProperties {
     public static class HeaderFields {
       private String thumbprint;
       private String distinguishedName;
+      private String fullCert;
+      private Boolean useFullCertificate = false;
     }
   }
 }

--- a/src/main/java/eu/interop/federationgateway/utils/CertificateUtils.java
+++ b/src/main/java/eu/interop/federationgateway/utils/CertificateUtils.java
@@ -20,12 +20,19 @@
 
 package eu.interop.federationgateway.utils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +45,8 @@ public class CertificateUtils {
   /**
    * Calculates the SHA-256 thumbprint of X509Certificate.
    *
-   * @param x509Certificate the certificate the thumbprint should be calculated for.
+   * @param x509Certificate the certificate the thumbprint should be calculated
+   *                        for.
    * @return 32-byte SHA-256 hash as hex encoded string
    */
   public static String getCertThumbprint(X509Certificate x509Certificate) {
@@ -53,7 +61,8 @@ public class CertificateUtils {
   /**
    * Calculates the SHA-256 thumbprint of X509CertificateHolder.
    *
-   * @param x509CertificateHolder the certificate the thumbprint should be calculated for.
+   * @param x509CertificateHolder the certificate the thumbprint should be
+   *                              calculated for.
    * @return 32-byte SHA-256 hash as hex encoded string
    */
   public static String getCertThumbprint(X509CertificateHolder x509CertificateHolder) {
@@ -61,6 +70,71 @@ public class CertificateUtils {
       return calculateHash(x509CertificateHolder.getEncoded());
     } catch (IOException | NoSuchAlgorithmException e) {
       log.error("Could not calculate thumbprint of certificate.");
+      return null;
+    }
+  }
+
+  /**
+   * Assumes we have a certificate in DER representation, somehow encoded to be
+   * transmitted in a header. This means either just the base64encoding of the DER
+   * representation, or any valid way of transmitting the PEM file, like escaping
+   * newlines or url encode newlines.
+   * 
+   * <p>We normalize the data and try to extract the DER bytes of the certificate,
+   * which we feed to another function, which then uses a {@link CertificateFactory} to get
+   * the encoded object.
+   *
+   *
+   * @param rawData the certificate as a PEM-String or quasi PEM-String (PEM
+   *                without newlines, no suffix/prefix).
+   * @return X509Certificate of rawData, or null if it could not be parsed
+   */
+  public static X509Certificate getCertificateFromRawString(String rawData) {
+    String normalizedData = rawData;
+    // Check if there is a % in the header (we assume this indicates urlencoding)
+    if (rawData.contains("%")) {
+      try {
+        normalizedData = URLDecoder.decode(normalizedData, StandardCharsets.UTF_8);
+      } catch (IllegalArgumentException ex) {
+        log.info("Data contains invalid url encoded characters, skipping");
+      }
+    }
+
+    normalizedData = normalizedData
+        // remove PEM prefix
+        .replace("-----BEGIN CERTIFICATE-----", "")
+        // remove escaped whitespaces
+        .replace("\\\\n", "").replace("\\n", "").replace("\\\\r", "").replace("\\r", "")
+        // remove PEM suffix
+        .replace("-----END CERTIFICATE-----", "")
+        // remove all whitespaces
+        .replace("\n", "")
+        .replace("\r", "")
+        .replace(" ", "").trim();
+    // now we should have a base64 encoded string of the DER-representation of the
+    // certificate
+    try {
+      byte[] derBytes = Base64.getDecoder().decode(normalizedData);
+      return getX509CertificateFromDer(derBytes);
+    } catch (IllegalArgumentException argumentException) {
+      log.error("Data is not valid base64");
+      return null;
+    }
+  }
+
+  /**
+   * Gets the X509Certificate from a DER representation thereof. This functions
+   * expects the bytes to be in the correct format.
+   *
+   * @param der the certificaten as a DER-bytes.
+   * @return X509Certificate of the DER bytes, or null if it could not be parsed
+   */
+  public static X509Certificate getX509CertificateFromDer(byte[] der) {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(der);
+    try {
+      Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(byteArrayInputStream);
+      return certificate instanceof X509Certificate ? (X509Certificate) certificate : null;
+    } catch (CertificateException ignored) {
       return null;
     }
   }

--- a/src/test/java/eu/interop/federationgateway/filter/CertAuthFilterTestWithFullCert.java
+++ b/src/test/java/eu/interop/federationgateway/filter/CertAuthFilterTestWithFullCert.java
@@ -1,0 +1,170 @@
+  /*-
+   * ---license-start
+   * EU-Federation-Gateway-Service / efgs-federation-gateway
+   * ---
+   * Copyright (C) 2020 - 2021 Ubique Innovation AG and all other contributors
+   * ---
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *      http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   * ---license-end
+   */
+
+  package eu.interop.federationgateway.filter;
+
+  import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+  import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+  import eu.interop.federationgateway.TestData;
+  import eu.interop.federationgateway.config.EfgsProperties;
+  import eu.interop.federationgateway.repository.CertificateRepository;
+  import eu.interop.federationgateway.repository.DiagnosisKeyBatchRepository;
+  import eu.interop.federationgateway.repository.DiagnosisKeyEntityRepository;
+  import eu.interop.federationgateway.testconfig.EfgsTestKeyStore;
+  import java.io.IOException;
+  import java.math.BigInteger;
+  import java.net.URLEncoder;
+  import java.nio.charset.StandardCharsets;
+  import java.security.InvalidKeyException;
+  import java.security.KeyStoreException;
+  import java.security.NoSuchAlgorithmException;
+  import java.security.SignatureException;
+  import java.security.cert.CertificateException;
+  import java.util.Base64;
+  import lombok.extern.slf4j.Slf4j;
+  import org.bouncycastle.operator.OperatorCreationException;
+  import org.junit.Assert;
+  import org.junit.Before;
+  import org.junit.Test;
+  import org.junit.runner.RunWith;
+  import org.springframework.beans.factory.annotation.Autowired;
+  import org.springframework.boot.test.context.SpringBootTest;
+  import org.springframework.test.context.ContextConfiguration;
+  import org.springframework.test.context.junit4.SpringRunner;
+  import org.springframework.test.web.servlet.MockMvc;
+  import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+  import org.springframework.web.context.WebApplicationContext;
+
+  @Slf4j
+  @SpringBootTest
+  @RunWith(SpringRunner.class)
+  @ContextConfiguration(classes = EfgsTestKeyStore.class)
+  public class CertAuthFilterTestWithFullCert {
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private EfgsProperties properties;
+
+    @Autowired
+    private DiagnosisKeyEntityRepository diagnosisKeyEntityRepository;
+
+    @Autowired
+    private DiagnosisKeyBatchRepository diagnosisKeyBatchRepository;
+
+    @Autowired
+    private CertificateAuthentificationFilter certFilter;
+
+    @Autowired
+    private CertificateRepository certificateRepository;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() throws CertificateException, NoSuchAlgorithmException, IOException, OperatorCreationException,
+        InvalidKeyException, SignatureException, KeyStoreException {
+      TestData.insertCertificatesForAuthentication(certificateRepository);
+
+      diagnosisKeyEntityRepository.deleteAll();
+      diagnosisKeyBatchRepository.deleteAll();
+      properties.getCertAuth().getHeaderFields().setUseFullCertificate(true);
+
+      mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilter(certFilter).build();
+    }
+
+    public String getPEMEncodedCertificate(byte[] certificate, String newline) {
+      String base64Der = Base64.getEncoder().encodeToString(certificate);
+
+      int start = 0;
+      int len = 64;
+      int length = base64Der.length();
+      StringBuilder sb = new StringBuilder();
+      sb.append("-----BEGIN CERTIFICATE-----" + newline);
+      while (start + len < length) {
+        sb.append(base64Der.substring(start, start + len));
+        sb.append(newline);
+        start += len;
+      }
+      if (start < length) {
+        sb.append(base64Der.substring(start, length));
+        sb.append(newline);
+      }
+      sb.append("-----END CERTIFICATE-----"+newline);
+      return sb.toString();
+    }
+
+    @Test
+    public void testRequestBase64DEREncodedCertificate() throws Exception {
+      String base64DERcertificate = Base64.getEncoder().encodeToString(TestData.validAuthenticationCertificate.getEncoded());
+
+      mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
+        .header(properties.getCertAuth().getHeaderFields().getFullCert(), base64DERcertificate)
+      ).andExpect(mvcResult -> {
+        Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
+      });
+    }
+
+    @Test
+    public void testRequestUrlEncodedPemCertificate() throws Exception {
+      String PemWindowsCertificate = getPEMEncodedCertificate(TestData.validAuthenticationCertificate.getEncoded(), "\n");
+      String urlEncodedPem = URLEncoder.encode(PemWindowsCertificate, StandardCharsets.UTF_8);
+
+      mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
+        .header(properties.getCertAuth().getHeaderFields().getFullCert(), urlEncodedPem)
+      ).andExpect(mvcResult -> {
+        Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
+      });
+    }
+
+    @Test
+    public void testRequestUrlEncodedPemWithWindowsLineEnding() throws Exception {
+      String PemWindowsCertificate = getPEMEncodedCertificate(TestData.validAuthenticationCertificate.getEncoded(), "\r\n");
+      String urlEncodedPem = URLEncoder.encode(PemWindowsCertificate, StandardCharsets.UTF_8);
+
+      mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
+        .header(properties.getCertAuth().getHeaderFields().getFullCert(), urlEncodedPem)
+      ).andExpect(mvcResult -> {
+        Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
+      });
+    }
+
+    @Test
+    public void testRequestPemWithEscapedLineEndings() throws Exception {
+      String PemEscapedLineEndingsCertificate = getPEMEncodedCertificate(TestData.validAuthenticationCertificate.getEncoded(), "\\n");
+
+      mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
+        .header(properties.getCertAuth().getHeaderFields().getFullCert(), PemEscapedLineEndingsCertificate)
+      ).andExpect(mvcResult -> {
+        Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
+      });
+    }
+
+    @Test
+    public void testRequestPemWithEscapedWindowsLineEndings() throws Exception {
+      String PemEscapedWindowsLineEndingsCertificate = getPEMEncodedCertificate(TestData.validAuthenticationCertificate.getEncoded(), "\\r\\n");
+
+      mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
+        .header(properties.getCertAuth().getHeaderFields().getFullCert(), PemEscapedWindowsLineEndingsCertificate)
+      ).andExpect(mvcResult -> {
+        Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
+      });
+    }
+  }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -54,6 +54,7 @@ efgs:
     header-fields:
       thumbprint: X-SSL-Client-SHA256
       distinguished-name: X-SSL-Client-DN
+      full-cert: X-SSL-Client-Cert
   batching:
     timeinterval: 300000
     doclimit: 5000


### PR DESCRIPTION
# Introduction

There are various implementations of Proxy/Load-Balancers and there is no standard agreed on, how to inform services behind the proxy of which certificate was used for mutual TLS. There are certain quasi standard headers, which have been established as a convention, to provide meta information about the certificate.
Sadly, there is no common ground on how to pass a representation of the certificate to said services. Whereas the original `EFGS` implementation uses the SHA-256 hash of the `DER`-representation of the certificate (aka fingerprint/thumbprint), the load balancer used for the Swiss implementation does not provide such a functionality. The Swiss load balancer only allows to pass on the full certificate to the service.

# Solution

In this PR we added new properties to control the header used for the certificate, and a flag indicating if the certificate fingerprint should be calculated from the full certificate. Furthermore, `CertificateUtils` has been extended to provide a function parsing a certificate in the `DER` encoding, either within a container (aka `PEM`) or by itself. It tries to normalize the given certificate in regards to newline encodings, and parses the `DER` bytes, creating a Java representation of a `X509` certificate, which then uses the methods in place to calculate the hash (aka fingerprint/tumbprint).
Further a copy of the original test class was modified to not send a fingerprint but rather provide the full certificate.