### PR TITLE
Add Migration to Increase `uploader_information_batch_signature` Column Size

### DIFF
--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -38,5 +38,6 @@ databaseChangeLog:
   - include:
       file: changelog/v001-change-certificate-signature-column-size.yml
       relativeToChangelogFile: true
-
-
+  - include:
+      file: changelog/v003-increase-column-size-for-batchsignature.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/v003-increase-column-size-for-batchsignature.yml
+++ b/src/main/resources/db/changelog/v003-increase-column-size-for-batchsignature.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: increase-column-size-for-batchsignature
+      author: ubamrein
+      changes:
+        - modifyDataType:
+            tableName: diagnosiskey
+            columnName: uploader_information_batch_signature
+            newDataType: varchar(8000)


### PR DESCRIPTION
Closes: https://github.com/eu-federation-gateway-service/efgs-federation-gateway/issues/276

We increase the column size to 8000 characters, to circumvent the issues of longer RSA keys in the certificates used for signing the uploaded batches. See the linked issue for further details.