### PR TITLE
Update Spring Boot to 2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- dependencies -->
     <owasp.version>6.1.1</owasp.version>
-    <spring.boot.version>2.4.3</spring.boot.version>
+    <spring.boot.version>2.4.5</spring.boot.version>
     <spring.cloud.version>2020.0.1</spring.cloud.version>
     <spring.test.version>5.3.4</spring.test.version>
     <spring.security.version>5.4.5</spring.security.version>


### PR DESCRIPTION
Currently the OWASP Check Job fails. The update to Spring Boot 2.4.5 includes an updated peer dependency which raised the failed OWASP check.

