### PR TITLE
Set Key Retention to 3 Days

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ efgs:
     maximum-upload-batch-size: 5000
   download-settings:
     locklimit: 1800000
-    max-age-in-days: 6
+    max-age-in-days: 2
   cert-auth:
     header-fields:
       thumbprint: X-SSL-Client-SHA256


### PR DESCRIPTION
Set the property for max age to 2 days. This ensures that no key exists longer than 72h in EFGS database.