### PR TITLE
Add Retry Logic for Cleanup Job

### DIFF
--- a/docs/software-design-federation-gateway-service.md
+++ b/docs/software-design-federation-gateway-service.md
@@ -177,6 +177,8 @@ These key-value-pairs can be followed by additional attributes. The additional a
 | Certificate integrity check failed: Could not use public key to initialize verifier. (initialization error) | ERROR | Could not use public key to initialize verifier. | certVerifyThumbprint |
 | Certificate integrity check failed: Signature verifier is not initialized (initialization error) | ERROR | Signature verifier is not initialized | certVerifyThumbprint |
 | Certificate integrity check failed: Unknown signing algorithm used by EFGS Trust Anchor. (initialization error) | ERROR | Unknown signing algorithm used by EFGS Trust Anchor. | certVerifyThumbprint |
+| **DB Cleanup**
+| DB Cleanup failed for unexpected reason. See exception for more details. Cleanup will be retried 6 times | ERROR | Failed to execute DB Cleanup Job | exception |
 
  
 # Integration into Data Center Infrastructure

--- a/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyCleanupService.java
+++ b/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyCleanupService.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -64,6 +65,11 @@ public class DiagnosisKeyCleanupService {
     EfgsMdc.put("deletedDiagnosisKeys", deletedDiagnosisKeys);
     EfgsMdc.put("deletedDiagnosisKeyBatches", deletedDiagnosisKeyBatches);
     log.info("DiagnosisKey and DiagnosisKeyBatch cleanup finished.");
+  }
+
+  @Recover
+  public void recover(RuntimeException e) {
+    log.error("Failed to execute DB Cleanup Job", e);
   }
 
 }

--- a/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyCleanupService.java
+++ b/src/main/java/eu/interop/federationgateway/service/DiagnosisKeyCleanupService.java
@@ -28,6 +28,8 @@ import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -48,6 +50,7 @@ public class DiagnosisKeyCleanupService {
   @Scheduled(cron = "0 0 0 * * *")
   @SchedulerLock(name = "DiagnosisKeyCleanupService_cleanupDiagnosisKeys", lockAtLeastFor = "PT0S",
     lockAtMostFor = "${efgs.download-settings.locklimit}")
+  @Retryable(value = RuntimeException.class, maxAttempts = 6, backoff = @Backoff(delay = 600_000))
   public void cleanupDiagnosisKeys() {
     ZonedDateTime deleteTimestamp = LocalDate.ofInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC)
       .atStartOfDay(ZoneOffset.UTC)


### PR DESCRIPTION
When the Cleanup Job failes it will be tried again after 10 minutes. This PR should mitigate failing cleanup when EFGS has high database load.