### PR TITLE
Fix: Liquibase Changelog when starting on blank MySql

### DIFF
--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -8,4 +8,13 @@
     <notes>no YAML content from users is parsed within this service</notes>
     <cve>CVE-2022-1471</cve>
   </suppress>
+  <suppress>
+    <notes>False positive, Version matcher "h2 1.3.197" matches to "h2 2.1.214"</notes>
+    <cve>CVE-2018-14335</cve>
+  </suppress>
+  <suppress>
+    <notes>False positive, both "hutool" and "json-java_project" are no dependencies of this project</notes>
+    <cve>CVE-2022-45688</cve>
+  </suppress>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
         <configuration>
           <suppressionFile>./owasp/suppressions.xml</suppressionFile>
           <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+          <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
         </configuration>
         <executions>
           <execution>

--- a/src/main/resources/db/changelog/v000-create-diagnosis-key-batch-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-diagnosis-key-batch-entity-table.yml
@@ -26,6 +26,8 @@ databaseChangeLog:
                   type: varchar(64)
   - changeSet:
       id: create-diagnosis-key-batch-entity-table-increment
+      validCheckSum:
+        - 8:5fafc0a959e1c26161fc8cb698c9f982
       author: dfischer-tech
       changes:
         - addAutoIncrement:

--- a/src/main/resources/db/changelog/v000-create-diagnosis-key-batch-entity-table.yml
+++ b/src/main/resources/db/changelog/v000-create-diagnosis-key-batch-entity-table.yml
@@ -33,7 +33,6 @@ databaseChangeLog:
             columnName: id
             columnDataType: bigint
             startWith: 1
-            incrementBy: 1
   - changeSet:
       id: create-diagnosis-key-batch-entity-table-indexes
       author: dfischer-tech


### PR DESCRIPTION
The Liquibase Changeset ```v000-create-diagnosis-key-batch-entity-table.yml``` contains an ```incrementBy``` property which is not supported by MySql. It's not required for our database schema.